### PR TITLE
Index out of bounds when notifyDataSetChanged() is called.

### DIFF
--- a/library/src/za/co/immedia/pinnedheaderlistview/SectionedBaseAdapter.java
+++ b/library/src/za/co/immedia/pinnedheaderlistview/SectionedBaseAdapter.java
@@ -127,6 +127,11 @@ public abstract class SectionedBaseAdapter extends BaseAdapter implements Pinned
     }
 
     public int getPositionInSectionForPosition(int position) {
+        // Little hack to avoid returning -1 if the position provided is 0-len ranged
+        if (position == 0) {
+    		position = 1;
+		}
+        
         // first try to retrieve values from cache
         Integer cachedPosition = mSectionPositionCache.get(position);
         if (cachedPosition != null) {


### PR DESCRIPTION
Hi there, I'm currently working with a `ListView` and a `Cursor` using this library. 

All works fine but when i try to change my adapter's cursor and notify that the content has changed, the `AdapterView` calls `SectionedBaseAdapter.getItemId()` (from `AdapterView.rememberSyncState()`) with `position = 0`, so the `getPositionInSectionForPosition(0)` call returns -1.

So, since `AdapterView` will **always** call that method with position 0 (and no one else), I just made this simple little hack.
